### PR TITLE
Implemented observation

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,6 +42,8 @@ jobs:
   build:
     name: Build
     runs-on: ${{ matrix.os }}
+    env:
+      VCPKG_BINARY_SOURCES: 'clear;files,C:\vcpkg\archives,readwrite'
 
     strategy:
       fail-fast: false
@@ -71,20 +73,29 @@ jobs:
         target:  ${{ matrix.target }}
         override: true
     
-    - name: Configure cargo caching 
+    - name: Configure linux caching
+      if: ${{ matrix.os != 'windows-latest' }}
       uses: actions/cache@v2
       with:
         key: ${{ matrix.os }}-${{ matrix.target }}
         path: |
-          ${{ env.HOME }}/.cargo"
-          target
+          ./target
+          /usr/share/rust/.cargo/.cargo/bin
+          /usr/share/rust/.cargo/.cargo/registry/index
+          /usr/share/rust/.cargo/.cargo/registry/cache
+          /usr/share/rust/.cargo/.cargo/git/db
     
-    - name: Configure vcpkg caching
+    - name: Configure windows caching
       if: ${{ matrix.os == 'windows-latest' }}
       uses: actions/cache@v2
       with:
         key: ${{ matrix.os }}-${{ matrix.target }}
-        path: ${{ env.HOME }}/vcpkg/archives
+        path: |
+          C:\vcpkg\archives
+          C:\Rust\.cargo\bin
+          C:\Rust\.cargo\registry\index
+          C:\Rust\.cargo\registry\cache
+          C:\Rust\.cargo\git\db
 
     - name: Install openssl (apt armv7)
       if: ${{ matrix.target == 'armv7-unknown-linux-gnueabihf' }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -84,7 +84,7 @@ jobs:
       uses: actions/cache@v2
       with:
         key: ${{ matrix.os }}-${{ matrix.target }}
-        path: C:/vcpkg
+        path: ${{ env.HOME }}/vcpkg/archives
 
     - name: Install openssl (apt armv7)
       if: ${{ matrix.target == 'armv7-unknown-linux-gnueabihf' }}

--- a/src/backend/backend_tokio/dtls.rs
+++ b/src/backend/backend_tokio/dtls.rs
@@ -73,11 +73,11 @@ impl Tokio {
                     ctl = ctl_rx.recv() => {
                         match ctl {
                             Some(Ctl::Register(token, rx)) => {
-                                debug!("Register handler: {}", token);
+                                debug!("Register handler: {:x}", token);
                                 handles.insert(token, rx);
                             },
                             Some(Ctl::Deregister(token)) => {
-                                debug!("Deregister handler: {}", token);
+                                debug!("Deregister handler: {:x}", token);
                                 handles.remove(&token);
                             },
                             Some(Ctl::Send(data)) => {

--- a/src/backend/backend_tokio/mod.rs
+++ b/src/backend/backend_tokio/mod.rs
@@ -5,14 +5,18 @@
 use std::collections::HashMap;
 use std::io::{Error, ErrorKind};
 use std::net::SocketAddr;
+use std::pin::Pin;
+use std::task::{Context, Poll};
 
-use coap_lite::{CoapResponse, MessageClass, MessageType, Packet};
+use futures::{Future, FutureExt, Stream};
+use coap_lite::{CoapOption, CoapResponse, MessageClass, MessageType, ObserveOption, Packet, RequestType};
 use log::{debug, error};
 
-use tokio::sync::mpsc::{channel, Sender};
+use tokio::sync::mpsc::{Receiver, Sender, channel};
 
-use super::Backend;
-use crate::RequestOptions;
+use crate::{RequestOptions, status_is_ok};
+use super::{Backend, Observer};
+
 
 mod dtls;
 mod udp;
@@ -51,37 +55,21 @@ impl Tokio {
         match packet.header.code {
             MessageClass::Response(_) => (),
             _ => {
-                debug!("packet was not response type: {:?}", packet);
-                return Err(Error::new(ErrorKind::InvalidData, "unexpected packet type"));
+                //debug!("packet was not response type: {:?}", packet);
+                //return Err(Error::new(ErrorKind::InvalidData, "unexpected packet type"));
             }
         };
 
         // Fetch token from packet
         let token = crate::token_as_u32(packet.get_token());
 
-        // Lookup response handle
-        let handle = handles.get(&token).map(|v| v.clone());
+        debug!("Received packet: {:x?}", packet);
 
-        // Return to caller or respond with failure
-        match handle {
-            Some(h) => {
-                debug!("Handled response: {:?}, forwarding to caller", packet);
-
-                // Forward to requester
-                h.send(packet.clone()).await.unwrap();
-
-                // Send acknowlegement if required
-                if packet.header.get_type() == MessageType::Confirmable {
-                    if let Some(mut ack) = CoapResponse::new(&packet) {
-                        ack.message.header.code = MessageClass::Empty;
-
-                        let encoded = ack.message.to_bytes().unwrap();
-                        tx.send(Ctl::Send(encoded)).await.unwrap();
-                    }
-                }
-            }
+        // Lookup response handle and send reset if no handle matches
+        let handle = match handles.get(&token).map(|v| v.clone()) {
+            Some(h) => h,
             None => {
-                debug!("Unhandled response: {:?}, sending reset", packet);
+                debug!("No registered handle for token: {:x}, sending reset", token);
 
                 // Send connection reset
                 let mut request = Packet::new();
@@ -92,7 +80,31 @@ impl Tokio {
 
                 let encoded = request.to_bytes().unwrap();
                 tx.send(Ctl::Send(encoded)).await.unwrap();
+
+                return Ok(())
             }
+        };
+
+        // Send acknowlegement if required
+        if packet.header.get_type() == MessageType::Confirmable {
+            if let Some(mut ack) = CoapResponse::new(&packet) {
+                debug!("Sending ACK for message: {}", packet.header.message_id);
+                ack.message.header.code = MessageClass::Empty;
+
+                let encoded = ack.message.to_bytes().unwrap();
+                tx.send(Ctl::Send(encoded)).await.unwrap();
+            }
+        }
+
+        debug!("Found response handler for packet: {:x}, forwarding to caller", token);
+
+        // Forward to requester
+        if let Err(_e) = handle.send(packet.clone()).await {
+            debug!("Response channel dropped, removing handler");
+            handles.remove(&token);
+
+            // TODO: we could also send a reset here?
+            // however, we'll get it next round anyway
         }
 
         Ok(())
@@ -129,40 +141,11 @@ impl Tokio {
         Ok(udp_sock)
     }
 
-    /// Close the CoAP client
-    pub async fn close(self) -> Result<(), Error> {
-        // TODO: disable observations when supported?
+    // Helper for running request / responses
+    async fn do_send_retry(ctl_tx: Sender<Ctl>, rx: &mut Receiver<Packet>, req: Packet, opts: RequestOptions) -> Result<Option<Packet>, Error> {
 
-        // Send exit command
-        match self.ctl_tx.send(Ctl::Exit).await {
-            Ok(_) => {
-                self._listener.await??;
-            }
-            Err(_) => self._listener.abort(),
-        }
-
-        Ok(())
-    }
-}
-
-#[async_trait::async_trait]
-impl Backend for Tokio {
-    type Error = Error;
-
-    async fn request(&mut self, req: Packet, opts: RequestOptions) -> Result<Packet, Self::Error> {
-        // Create request handle
-        let (tx, mut rx) = channel(10);
-        let token = crate::token_as_u32(req.get_token());
-
-        // Register handler
-        if let Err(e) = self.ctl_tx.send(Ctl::Register(token, tx)).await {
-            error!("Register send error: {:?}", e);
-            return Err(Error::new(ErrorKind::Other, "Register send failed"));
-        }
-
-        // For the allowed number of retries
+        // Send request and await response for the allowed number of retries
         let mut resp = Ok(None);
-
         for i in 0..opts.retries {
             // TODO: control / bump message_id each retry?
 
@@ -170,7 +153,7 @@ impl Backend for Tokio {
             let data = req.to_bytes().unwrap();
 
             // Issue request
-            if let Err(e) = self.ctl_tx.send(Ctl::Send(data)).await {
+            if let Err(e) = ctl_tx.send(Ctl::Send(data)).await {
                 error!("Raw send error: {:?}", e);
                 break;
             }
@@ -189,8 +172,26 @@ impl Backend for Tokio {
             };
         }
 
+        resp
+    }
+
+    // Helper for executing requests
+    async fn do_request(ctl_tx: Sender<Ctl>, req: Packet, opts: RequestOptions) -> Result<Packet, Error> {
+        // Create request handle
+        let (tx, mut rx) = channel(10);
+        let token = crate::token_as_u32(req.get_token());
+
+        // Register handler
+        if let Err(e) = ctl_tx.send(Ctl::Register(token, tx)).await {
+            error!("Register send error: {:?}", e);
+            return Err(Error::new(ErrorKind::Other, "Register send failed"));
+        }
+
+        // Send request and await response for the allowed number of retries
+        let resp = Self::do_send_retry(ctl_tx.clone(), &mut rx, req, opts).await;
+
         // Remove handler
-        if let Err(e) = self.ctl_tx.send(Ctl::Deregister(token)).await {
+        if let Err(e) = ctl_tx.send(Ctl::Deregister(token)).await {
             error!("Deregister send error: {:?}", e);
             return Err(Error::new(ErrorKind::Other, "Deregister send failed"));
         }
@@ -202,7 +203,256 @@ impl Backend for Tokio {
             Err(e) => Err(e),
         }
     }
+
+    // Helper for executing observations
+    async fn do_observe(ctl_tx: Sender<Ctl>, resource: String, opts: RequestOptions) -> Result<(u32, Receiver<Packet>), Error> {
+        debug!("Setup observe for resource: {}", resource);
+
+        // Create response channel
+        let (tx, mut rx) = channel(10);
+
+        // Create token
+        let token = rand::random::<u32>();
+
+        // Register handler
+        if let Err(e) = ctl_tx.send(Ctl::Register(token, tx.clone())).await {
+            error!("Register send error: {:?}", e);
+            return Err(Error::new(ErrorKind::Other, "Register send failed"));
+        }
+
+        // Build register packet
+        let mut register = Packet::new();
+        // TODO: message ID technically managed by higher level atm
+        // probably should be consistent?
+        register.header.message_id = rand::random();
+        register.header.code = MessageClass::Request(RequestType::Get);
+        register.header.set_type(MessageType::Confirmable);
+        register.set_token(token.to_be_bytes().to_vec());
+        
+        let res = resource.trim_start_matches("/");
+        register.add_option(CoapOption::UriPath, res.as_bytes().to_vec());
+        register.set_observe(vec![ObserveOption::Register as u8]);
+
+        // Execute register command
+
+        // Send request and await response for the allowed number of retries
+        let resp = Self::do_send_retry(ctl_tx.clone(), &mut rx, register, opts).await;
+
+        // Handle responses
+        match resp {
+            Ok(Some(v)) => {
+                // TODO: check response code is OK (2.xx)
+
+
+                // Check observe response
+                // Technically the server should respond with an empty observe...
+                // however libcoap does not appear to do this
+                // https://tools.ietf.org/html/rfc7641#section-3.1
+                let ok = match v.get_observe() {
+                    None => true,
+                    Some(o) if o.len() == 0 => true,
+                    Some(o) if o[0] == 0 => true,
+                    _ => false,
+                };
+                
+                if ok {
+                    debug!("Registered observer!");
+
+                    // TODO: Forward response if it's valid GET data
+
+                    Ok((token, rx))
+
+                } else {
+                    debug!("Server refused observe request");
+                    let _ = ctl_tx.send(Ctl::Deregister(token)).await;
+                    Err(Error::new(ErrorKind::ConnectionRefused, "Observe request refused"))
+                }
+            },
+            Ok(None) => {
+                debug!("Timeout registering observer");
+                let _ = ctl_tx.send(Ctl::Deregister(token)).await;
+                Err(Error::new(ErrorKind::TimedOut, "Request timed out"))
+            },
+            Err(e) => {
+                debug!("Error registering ovbserver: {:?}", e);
+                let _ = ctl_tx.send(Ctl::Deregister(token)).await;
+                Err(e)
+            },
+        }
+    }
+
+    async fn do_unobserve(ctl_tx: Sender<Ctl>, token: u32, resource: String, rx: Option<Receiver<Packet>>) -> Result<(), Error> {
+        debug!("Deregister observer: {:x}", token);
+
+        // Send de-register command
+        // Note this is not -technically- required as the next observe
+        // response will prompt a Reset, however, it's nice to do
+        // https://tools.ietf.org/html/rfc7641#section-3.6
+        if let Some(mut rx) = rx {
+
+            let mut deregister = Packet::new();
+            deregister.header.message_id = rand::random();
+            deregister.header.code = MessageClass::Request(RequestType::Get);
+            deregister.header.set_type(MessageType::Confirmable);
+            deregister.set_token(token.to_be_bytes().to_vec());
+
+            let res = resource.trim_start_matches("/");
+            deregister.add_option(CoapOption::UriPath, res.as_bytes().to_vec());
+            deregister.set_observe(vec![ObserveOption::Deregister as u8]);
+
+            // Send de-register with retries
+            let resp = Self::do_send_retry(ctl_tx.clone(), &mut rx, deregister, RequestOptions::default()).await;
+
+            debug!("Deregister response: {:?}", resp);
+
+            match resp {
+                Ok(Some(v)) => {
+                    debug!("Deregister response: {:?}", v);
+
+                    match v.header.code {
+                        MessageClass::Response(s) if !status_is_ok(s) => {
+                            debug!("Deregister error (code: {:?})", s);
+                            // TODO: propagate error
+                        },
+                        _ => {
+                            debug!("Deregister OK!");
+                        },
+                    }
+                },
+                Ok(None) => {
+                    debug!("Deregister request timed out");
+                },
+                Err(e) => {
+                    debug!("Error sending deregister request: {:?}", e);
+                }
+            }
+        }
+
+        // De-register local handler
+        if let Err(e) = ctl_tx.try_send(Ctl::Deregister(token)) {
+            debug!("Error sending deregister command: {:?}", e)
+        }
+
+        Ok(())
+    }
+
+    /// Close the CoAP client
+    pub async fn close(self) -> Result<(), Error> {
+        // TODO: disable observations when supported?
+
+        // Send exit command
+        match self.ctl_tx.send(Ctl::Exit).await {
+            Ok(_) => {
+                self._listener.await??;
+            }
+            Err(_) => self._listener.abort(),
+        }
+
+        Ok(())
+    }
 }
+
+/// Async request type for Tokio backend
+// TODO: it'd be great to not have to box this?
+// Unfortunately this would appear require unwrapping the future states in
+// do_request, and because Tokio uses `async` functions the output of each
+// of these is an opaque type, so we may always have to box </3
+pub struct TokioRequest<T> {
+    inner: Pin<Box<dyn Future<Output = Result<T, Error>>>>,
+}
+
+impl <T> Future for TokioRequest<T>
+{
+    type Output = Result<T, Error>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.inner.poll_unpin(cx)
+    }
+}
+
+pub struct TokioObserve {
+    token: u32,
+    resource: String,
+    inner: ObserveState,
+}
+
+pub enum ObserveState {
+    Init(Pin<Box<dyn Future<Output = Result<(u32, Receiver<Packet>), Error>>>>),
+    Stream(Receiver<Packet>),
+}
+
+impl Observer<Error> for TokioObserve {
+    fn token(&self) -> u32 {
+        self.token
+    }
+
+    fn resource(&self) -> &str {
+        &self.resource
+    }
+}
+
+impl Stream for TokioObserve {
+    type Item = Result<Packet, Error>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        match &mut self.as_mut().inner {
+            // Handle init state, establishing observation
+            ObserveState::Init(s) => {
+                match s.poll_unpin(cx) {
+                    Poll::Ready(Ok((token, stream))) => {
+                        // Set token and new stream
+                        self.token = token;
+                        self.inner = ObserveState::Stream(stream);
+                        // Signal waker to immediately re-poll on the stream
+                        cx.waker().clone().wake();
+                        Poll::Pending
+                    },
+                    Poll::Ready(Err(e)) => {
+                        Poll::Ready(Some(Err(e)))
+                    },
+                    Poll::Pending => Poll::Pending,
+                }
+            },
+            // Handle streaming state, polling on receive
+            ObserveState::Stream(s) => {
+                match s.poll_recv(cx) {
+                    Poll::Ready(Some(p)) => Poll::Ready(Some(Ok(p))),
+                    Poll::Ready(None) => Poll::Ready(None),
+                    Poll::Pending => Poll::Pending
+                }
+            }
+        }
+    }
+}
+
+
+impl Backend<std::io::Error> for Tokio 
+{
+    type Request = TokioRequest<Packet>;
+    type Observe = TokioObserve;
+    type Unobserve = TokioRequest<()>;
+
+    fn request(&mut self, req: Packet, opts: RequestOptions) -> Self::Request {
+        let inner = Tokio::do_request(self.ctl_tx.clone(), req, opts);
+        TokioRequest{ inner: Box::pin(inner) }
+    }
+
+    fn observe(&mut self, resource: String, opts: RequestOptions) -> Self::Observe {
+        let init = Tokio::do_observe(self.ctl_tx.clone(), resource.clone(), opts);
+        TokioObserve{ token: 0, resource, inner: ObserveState::Init(Box::pin(init)) }
+    }
+
+    fn unobserve(&mut self, o: Self::Observe) -> Self::Unobserve {
+        let rx = match o.inner {
+            ObserveState::Init(_) => None,
+            ObserveState::Stream(s) => Some(s),
+        };
+
+        let inner = Tokio::do_unobserve(self.ctl_tx.clone(), o.token, o.resource, rx);
+        TokioRequest{ inner: Box::pin(inner) }
+    }
+}
+
 
 #[cfg(test)]
 mod test {
@@ -218,10 +468,30 @@ mod test {
             .unwrap();
 
         let resp = client
-            .get("hello", RequestOptions::default())
+            .get("hello", &RequestOptions::default())
             .await
             .unwrap();
         assert_eq!(resp, b"world".to_vec());
+
+        client.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    #[ignore = "separate responses not yet implemented"]
+    async fn test_get_udp_separate() {
+        let _ = SimpleLogger::init(LevelFilter::Debug, Config::default());
+
+        let mut client = TokioClient::connect("coap://coap.me:5683", &ClientOptions::default())
+            .await
+            .unwrap();
+
+        let resp = client
+            .get("separate", &RequestOptions::default())
+            .await
+            .unwrap();
+        assert_eq!(resp, b"separate".to_vec());
+
+        client.close().await.unwrap();
     }
 
     #[tokio::test]
@@ -234,7 +504,7 @@ mod test {
             .unwrap();
 
         let resp = client
-            .get("hello", RequestOptions::default())
+            .get("hello", &RequestOptions::default())
             .await
             .unwrap();
         assert_eq!(resp, b"world".to_vec());

--- a/src/backend/backend_tokio/udp.rs
+++ b/src/backend/backend_tokio/udp.rs
@@ -35,11 +35,11 @@ impl Tokio {
                     ctl = ctl_rx.recv() => {
                         match ctl {
                             Some(Ctl::Register(token, rx)) => {
-                                debug!("Register handler: {}", token);
+                                debug!("Register handler: {:x}", token);
                                 handles.insert(token, rx);
                             },
                             Some(Ctl::Deregister(token)) => {
-                                debug!("Deregister handler: {}", token);
+                                debug!("Deregister handler: {:x}", token);
                                 handles.remove(&token);
                             },
                             Some(Ctl::Send(data)) => {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -2,7 +2,8 @@
 // https://github.com/ryankurte/rust-coap-client
 // Copyright 2021 ryan kurte <ryan@kurte.nz>
 
-use coap_lite::Packet;
+use futures::{Future, Stream};
+use coap_lite::{Packet};
 
 use crate::RequestOptions;
 
@@ -12,12 +13,22 @@ pub mod backend_tokio;
 #[cfg(feature = "backend-tokio")]
 pub use backend_tokio::Tokio;
 
-/// Generic transport trait for implementing CoAP client backends
-// TODO: swap this to an associated future type so it's box-free,
-// requires re-working the tokio driver to a future object
-#[async_trait::async_trait]
-pub trait Backend {
-    type Error;
+pub trait Observer<E>: Stream<Item = Result<Packet, E>> {
+    /// Fetch the observer token
+    fn token(&self) -> u32;
+    /// Fetch the observer resource
+    fn resource(&self) -> &str;
+}
 
-    async fn request(&mut self, req: Packet, opts: RequestOptions) -> Result<Packet, Self::Error>;
+/// Generic transport trait for implementing CoAP client backends
+pub trait Backend<E> {
+    type Request: Future<Output = Result<Packet, E>>;
+    type Observe: Observer<E>;
+    type Unobserve: Future<Output = Result<(), E>>;
+
+    fn request(&mut self, req: Packet, opts: RequestOptions) -> Self::Request;
+
+    fn observe(&mut self, resource: String, opts: RequestOptions) -> Self::Observe;
+
+    fn unobserve(&mut self, o: Self::Observe) -> Self::Unobserve;
 }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -2,8 +2,8 @@
 // https://github.com/ryankurte/rust-coap-client
 // Copyright 2021 ryan kurte <ryan@kurte.nz>
 
+use coap_lite::Packet;
 use futures::{Future, Stream};
-use coap_lite::{Packet};
 
 use crate::RequestOptions;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,12 @@
+use std::str::FromStr;
+use std::time::Duration;
 /// Rust Async CoAP Client
 // https://github.com/ryankurte/rust-coap-client
 // Copyright 2021 ryan kurte <ryan@kurte.nz>
-
-use std::{convert::{TryFrom, TryInto}, marker::PhantomData};
-use std::str::FromStr;
-use std::time::Duration;
+use std::{
+    convert::{TryFrom, TryInto},
+    marker::PhantomData,
+};
 
 use log::{debug, error};
 use structopt::StructOpt;
@@ -215,7 +217,7 @@ impl TryFrom<&str> for HostOptions {
 /// Generic (async) CoAP client
 pub struct Client<E, T: Backend<E>> {
     transport: T,
-    _e: PhantomData<E>
+    _e: PhantomData<E>,
 }
 
 #[cfg(feature = "backend-tokio")]
@@ -357,7 +359,6 @@ where
         let resp = self.request(Method::Post, resource, data, opts).await?;
         Ok(resp.payload)
     }
-
 }
 
 fn token_as_u32(token: &[u8]) -> u32 {

--- a/src/util.rs
+++ b/src/util.rs
@@ -4,7 +4,8 @@
 
 use std::convert::{TryFrom, TryInto};
 
-use log::debug;
+use futures::{StreamExt};
+use log::{debug, info, error};
 use simplelog::{LevelFilter, SimpleLogger, TermLogger, TerminalMode};
 use structopt::StructOpt;
 
@@ -116,37 +117,65 @@ async fn main() -> Result<(), anyhow::Error> {
 
     debug!("Connected, executing command");
 
-    for _i in 0..opts.repeat {
-        // Perform operation
-        let resp = match &opts.command {
-            Command::Get => {
-                client
-                    .get(&opts.target.resource, &opts.request_opts)
-                    .await?
-            }
-            Command::Put(data) => {
-                let d: Option<Vec<u8>> = data.try_into()?;
-                client
-                    .put(&opts.target.resource, d.as_deref(), &opts.request_opts)
-                    .await?
-            }
-            Command::Post(data) => {
-                let d: Option<Vec<u8>> = data.try_into()?;
-                client
-                    .post(&opts.target.resource, d.as_deref(), &opts.request_opts)
-                    .await?
-            }
-            Command::Observe => {
-                // TODO: implement and run observe
-                unimplemented!()
-            }
-        };
+    // Run observation
+    if let Command::Observe = &opts.command {
+        // Create observer
+        let mut o = client.observe(&opts.target.resource, &opts.request_opts).await;
 
-        // Display response
-        // TODO: accept data options here (string, hex, write-to-file)
-        match std::str::from_utf8(&resp) {
-            Ok(s) => println!("{}", s),
-            Err(_) => println!("{:02x?}", resp),
+        // Await messages
+        loop {
+            tokio::select! {
+                r = o.next() => {
+                    match r {
+                        Some(Ok(d)) => {
+                            debug!("Observe RX: {:?}", d);
+                            display_resp(&d.payload)
+                        },
+                        Some(Err(e)) => {
+                            error!("Observe error: {:?}", e);
+                            break;
+                        },
+                        None => {
+                            info!("Observe channel closed");
+                            break;
+                        }
+                    }
+                },
+                _ = tokio::signal::ctrl_c() => {
+                    break;
+                }
+            }
+        }
+
+        // Destroy observer
+        client.unobserve(o).await?;
+
+    // Perform basic commands
+    } else {
+        for _i in 0..opts.repeat {
+            match &opts.command {
+                Command::Get => {
+                    let r = client
+                        .get(&opts.target.resource, &opts.request_opts)
+                        .await?;
+                    display_resp(&r);
+                }
+                Command::Put(data) => {
+                    let d: Option<Vec<u8>> = data.try_into()?;
+                    let r = client
+                        .put(&opts.target.resource, d.as_deref(), &opts.request_opts)
+                        .await?;
+                    display_resp(&r);
+                }
+                Command::Post(data) => {
+                    let d: Option<Vec<u8>> = data.try_into()?;
+                    let r = client
+                        .post(&opts.target.resource, d.as_deref(), &opts.request_opts)
+                        .await?;
+                    display_resp(&r);
+                },
+                _ => ()
+            };
         }
     }
 
@@ -156,4 +185,14 @@ async fn main() -> Result<(), anyhow::Error> {
     }
 
     Ok(())
+}
+
+// Display response
+// TODO: accept data options here (string, hex, write-to-file)
+fn display_resp(d: &[u8]) {
+    match std::str::from_utf8(&d) {
+        Ok(s) if s.len() > 0 => println!("Received: {}", s),
+        Err(_) if d.len() > 0 => println!("Received: {:02x?}", d),
+        _ => (),
+    }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -4,8 +4,8 @@
 
 use std::convert::{TryFrom, TryInto};
 
-use futures::{StreamExt};
-use log::{debug, info, error};
+use futures::StreamExt;
+use log::{debug, error, info};
 use simplelog::{LevelFilter, SimpleLogger, TermLogger, TerminalMode};
 use structopt::StructOpt;
 
@@ -120,7 +120,9 @@ async fn main() -> Result<(), anyhow::Error> {
     // Run observation
     if let Command::Observe = &opts.command {
         // Create observer
-        let mut o = client.observe(&opts.target.resource, &opts.request_opts).await;
+        let mut o = client
+            .observe(&opts.target.resource, &opts.request_opts)
+            .await;
 
         // Await messages
         loop {
@@ -173,8 +175,8 @@ async fn main() -> Result<(), anyhow::Error> {
                         .post(&opts.target.resource, d.as_deref(), &opts.request_opts)
                         .await?;
                     display_resp(&r);
-                },
-                _ => ()
+                }
+                _ => (),
             };
         }
     }


### PR DESCRIPTION
per [rfc7641](https://tools.ietf.org/html/rfc7641)

- re-worked backend to static types
  - this requires boxed wrappers for the tokio implementation (which is no worse than async_trait)
- added observe / unobserve methods to the client object
- tested against libcoap