### PR TITLE
Fix ordering issue where observe could be called but not complete prior to returning

### DIFF
--- a/src/backend/backend_tokio/mod.rs
+++ b/src/backend/backend_tokio/mod.rs
@@ -354,7 +354,6 @@ impl Tokio {
             }
         }
 
-
         // De-register local handler
         if let Err(e) = ctl_tx.try_send(Ctl::Deregister(token)) {
             debug!("Error sending deregister command: {:?}", e)
@@ -406,7 +405,6 @@ pub struct TokioObserve {
 
 unsafe impl Send for TokioObserve {}
 
-
 impl Observer<Error> for TokioObserve {
     fn token(&self) -> u32 {
         self.token
@@ -433,16 +431,24 @@ impl Stream for TokioObserve {
 impl Backend<std::io::Error> for Tokio {
     type Observe = TokioObserve;
 
-    async fn request(&mut self, req: Packet, opts: RequestOptions) -> Result<Packet, std::io::Error> {
+    async fn request(
+        &mut self,
+        req: Packet,
+        opts: RequestOptions,
+    ) -> Result<Packet, std::io::Error> {
         Tokio::do_request(self.ctl_tx.clone(), req, opts).await
     }
 
-    async fn observe(&mut self, resource: String, opts: RequestOptions) -> Result<Self::Observe, std::io::Error> {
+    async fn observe(
+        &mut self,
+        resource: String,
+        opts: RequestOptions,
+    ) -> Result<Self::Observe, std::io::Error> {
         let (token, rx) = Tokio::do_observe(self.ctl_tx.clone(), resource.clone(), opts).await?;
         Ok(TokioObserve {
             token,
             resource,
-            rx
+            rx,
         })
     }
 

--- a/src/backend/backend_tokio/mod.rs
+++ b/src/backend/backend_tokio/mod.rs
@@ -302,7 +302,7 @@ impl Tokio {
         ctl_tx: Sender<Ctl>,
         token: u32,
         resource: String,
-        rx: Option<Receiver<Packet>>,
+        mut rx: Receiver<Packet>,
     ) -> Result<(), Error> {
         debug!("Deregister observer: {:x}", token);
 
@@ -310,50 +310,50 @@ impl Tokio {
         // Note this is not -technically- required as the next observe
         // response will prompt a Reset, however, it's nice to do
         // https://tools.ietf.org/html/rfc7641#section-3.6
-        if let Some(mut rx) = rx {
-            let mut deregister = Packet::new();
-            deregister.header.message_id = rand::random();
-            deregister.header.code = MessageClass::Request(RequestType::Get);
-            deregister.header.set_type(MessageType::Confirmable);
-            deregister.set_token(token.to_le_bytes().to_vec());
 
-            let res = resource.trim_start_matches("/");
-            deregister.add_option(CoapOption::UriPath, res.as_bytes().to_vec());
-            deregister.set_observe(vec![ObserveOption::Deregister as u8]);
+        let mut deregister = Packet::new();
+        deregister.header.message_id = rand::random();
+        deregister.header.code = MessageClass::Request(RequestType::Get);
+        deregister.header.set_type(MessageType::Confirmable);
+        deregister.set_token(token.to_le_bytes().to_vec());
 
-            // Send de-register with retries
-            let resp = Self::do_send_retry(
-                ctl_tx.clone(),
-                &mut rx,
-                deregister,
-                RequestOptions::default(),
-            )
-            .await;
+        let res = resource.trim_start_matches("/");
+        deregister.add_option(CoapOption::UriPath, res.as_bytes().to_vec());
+        deregister.set_observe(vec![ObserveOption::Deregister as u8]);
 
-            debug!("Deregister response: {:?}", resp);
+        // Send de-register with retries
+        let resp = Self::do_send_retry(
+            ctl_tx.clone(),
+            &mut rx,
+            deregister,
+            RequestOptions::default(),
+        )
+        .await;
 
-            match resp {
-                Ok(Some(v)) => {
-                    debug!("Deregister response: {:?}", v);
+        debug!("Deregister response: {:?}", resp);
 
-                    match v.header.code {
-                        MessageClass::Response(s) if !status_is_ok(s) => {
-                            debug!("Deregister error (code: {:?})", s);
-                            // TODO: propagate error
-                        }
-                        _ => {
-                            debug!("Deregister OK!");
-                        }
+        match resp {
+            Ok(Some(v)) => {
+                debug!("Deregister response: {:?}", v);
+
+                match v.header.code {
+                    MessageClass::Response(s) if !status_is_ok(s) => {
+                        debug!("Deregister error (code: {:?})", s);
+                        // TODO: propagate error
+                    }
+                    _ => {
+                        debug!("Deregister OK!");
                     }
                 }
-                Ok(None) => {
-                    debug!("Deregister request timed out");
-                }
-                Err(e) => {
-                    debug!("Error sending deregister request: {:?}", e);
-                }
+            }
+            Ok(None) => {
+                debug!("Deregister request timed out");
+            }
+            Err(e) => {
+                debug!("Error sending deregister request: {:?}", e);
             }
         }
+
 
         // De-register local handler
         if let Err(e) = ctl_tx.try_send(Ctl::Deregister(token)) {
@@ -401,15 +401,11 @@ unsafe impl<T> Send for TokioRequest<T> {}
 pub struct TokioObserve {
     token: u32,
     resource: String,
-    inner: ObserveState,
+    rx: Receiver<Packet>,
 }
 
 unsafe impl Send for TokioObserve {}
 
-pub enum ObserveState {
-    Init(Pin<Box<dyn Future<Output = Result<(u32, Receiver<Packet>), Error>>>>),
-    Stream(Receiver<Packet>),
-}
 
 impl Observer<Error> for TokioObserve {
     fn token(&self) -> u32 {
@@ -425,63 +421,33 @@ impl Stream for TokioObserve {
     type Item = Result<Packet, Error>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        match &mut self.as_mut().inner {
-            // Handle init state, establishing observation
-            ObserveState::Init(s) => {
-                match s.poll_unpin(cx) {
-                    Poll::Ready(Ok((token, stream))) => {
-                        // Set token and new stream
-                        self.token = token;
-                        self.inner = ObserveState::Stream(stream);
-                        // Signal waker to immediately re-poll on the stream
-                        cx.waker().clone().wake();
-                        Poll::Pending
-                    }
-                    Poll::Ready(Err(e)) => Poll::Ready(Some(Err(e))),
-                    Poll::Pending => Poll::Pending,
-                }
-            }
-            // Handle streaming state, polling on receive
-            ObserveState::Stream(s) => match s.poll_recv(cx) {
-                Poll::Ready(Some(p)) => Poll::Ready(Some(Ok(p))),
-                Poll::Ready(None) => Poll::Ready(None),
-                Poll::Pending => Poll::Pending,
-            },
+        match self.rx.poll_recv(cx) {
+            Poll::Ready(Some(p)) => Poll::Ready(Some(Ok(p))),
+            Poll::Ready(None) => Poll::Ready(None),
+            Poll::Pending => Poll::Pending,
         }
     }
 }
 
+#[async_trait::async_trait]
 impl Backend<std::io::Error> for Tokio {
-    type Request = TokioRequest<Packet>;
     type Observe = TokioObserve;
-    type Unobserve = TokioRequest<()>;
 
-    fn request(&mut self, req: Packet, opts: RequestOptions) -> Self::Request {
-        let inner = Tokio::do_request(self.ctl_tx.clone(), req, opts);
-        TokioRequest {
-            inner: Box::pin(inner),
-        }
+    async fn request(&mut self, req: Packet, opts: RequestOptions) -> Result<Packet, std::io::Error> {
+        Tokio::do_request(self.ctl_tx.clone(), req, opts).await
     }
 
-    fn observe(&mut self, resource: String, opts: RequestOptions) -> Self::Observe {
-        let init = Tokio::do_observe(self.ctl_tx.clone(), resource.clone(), opts);
-        TokioObserve {
-            token: 0,
+    async fn observe(&mut self, resource: String, opts: RequestOptions) -> Result<Self::Observe, std::io::Error> {
+        let (token, rx) = Tokio::do_observe(self.ctl_tx.clone(), resource.clone(), opts).await?;
+        Ok(TokioObserve {
+            token,
             resource,
-            inner: ObserveState::Init(Box::pin(init)),
-        }
+            rx
+        })
     }
 
-    fn unobserve(&mut self, o: Self::Observe) -> Self::Unobserve {
-        let rx = match o.inner {
-            ObserveState::Init(_) => None,
-            ObserveState::Stream(s) => Some(s),
-        };
-
-        let inner = Tokio::do_unobserve(self.ctl_tx.clone(), o.token, o.resource, rx);
-        TokioRequest {
-            inner: Box::pin(inner),
-        }
+    async fn unobserve(&mut self, o: Self::Observe) -> Result<(), std::io::Error> {
+        Tokio::do_unobserve(self.ctl_tx.clone(), o.token, o.resource, o.rx).await
     }
 }
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -3,6 +3,7 @@
 // Copyright 2021 ryan kurte <ryan@kurte.nz>
 
 use coap_lite::Packet;
+use async_trait::async_trait;
 use futures::{Future, Stream};
 
 use crate::RequestOptions;
@@ -21,14 +22,13 @@ pub trait Observer<E>: Stream<Item = Result<Packet, E>> + Send {
 }
 
 /// Generic transport trait for implementing CoAP client backends
+#[async_trait]
 pub trait Backend<E>: Send {
-    type Request: Future<Output = Result<Packet, E>> + Send;
     type Observe: Observer<E>;
-    type Unobserve: Future<Output = Result<(), E>> + Send;
 
-    fn request(&mut self, req: Packet, opts: RequestOptions) -> Self::Request;
+    async fn request(&mut self, req: Packet, opts: RequestOptions) -> Result<Packet, E>;
 
-    fn observe(&mut self, resource: String, opts: RequestOptions) -> Self::Observe;
+    async fn observe(&mut self, resource: String, opts: RequestOptions) -> Result<Self::Observe, E>;
 
-    fn unobserve(&mut self, o: Self::Observe) -> Self::Unobserve;
+    async fn unobserve(&mut self, o: Self::Observe) -> Result<(), E>;
 }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -2,8 +2,8 @@
 // https://github.com/ryankurte/rust-coap-client
 // Copyright 2021 ryan kurte <ryan@kurte.nz>
 
-use coap_lite::Packet;
 use async_trait::async_trait;
+use coap_lite::Packet;
 use futures::{Future, Stream};
 
 use crate::RequestOptions;
@@ -28,7 +28,8 @@ pub trait Backend<E>: Send {
 
     async fn request(&mut self, req: Packet, opts: RequestOptions) -> Result<Packet, E>;
 
-    async fn observe(&mut self, resource: String, opts: RequestOptions) -> Result<Self::Observe, E>;
+    async fn observe(&mut self, resource: String, opts: RequestOptions)
+        -> Result<Self::Observe, E>;
 
     async fn unobserve(&mut self, o: Self::Observe) -> Result<(), E>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -330,7 +330,9 @@ where
         resource: &str,
         opts: &RequestOptions,
     ) -> Result<<T as Backend<E>>::Observe, E> {
-        self.transport.observe(resource.to_string(), opts.clone()).await
+        self.transport
+            .observe(resource.to_string(), opts.clone())
+            .await
     }
 
     /// Deregister an observation

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -329,8 +329,8 @@ where
         &mut self,
         resource: &str,
         opts: &RequestOptions,
-    ) -> <T as Backend<E>>::Observe {
-        self.transport.observe(resource.to_string(), opts.clone())
+    ) -> Result<<T as Backend<E>>::Observe, E> {
+        self.transport.observe(resource.to_string(), opts.clone()).await
     }
 
     /// Deregister an observation

--- a/src/util.rs
+++ b/src/util.rs
@@ -122,7 +122,7 @@ async fn main() -> Result<(), anyhow::Error> {
         // Create observer
         let mut o = client
             .observe(&opts.target.resource, &opts.request_opts)
-            .await;
+            .await?;
 
         // Await messages
         loop {


### PR DESCRIPTION
Swap backend abstraction over to `async_trait` and await on observe requests to ensure this occurs correctly.