### PR TITLE
fix formatting of error field

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,7 +103,7 @@ pub enum Transport {
 // TODO: impl std::error::Error via thiserror
 #[derive(Debug, thiserror::Error)]
 pub enum Error<T: std::fmt::Debug> {
-    #[error("Transport / Backend error: {:?}", 0)]
+    #[error("Transport / Backend error: {0:?}")]
     Transport(T),
     #[error("Invalid host specification")]
     InvalidHost,


### PR DESCRIPTION
With the current code transport errors are incorrectly formatted as `Transport / Backend error: 0`. This PR fixes this, errors will then be correctly formatted as e.g. `Transport / Backend error: Custom { kind: TimedOut, error: "Request timed out" }`.